### PR TITLE
Create RestrictSecurityGroupChanges.json

### DIFF
--- a/SCP/RestrictSecurityGroupChanges.json
+++ b/SCP/RestrictSecurityGroupChanges.json
@@ -1,0 +1,28 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenySecurityGroupChanges",
+      "Effect": "Deny",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupIngress",
+        "ec2:CreateSecurityGroup",
+        "ec2:DeleteSecurityGroup",
+        "ec2:ModifySecurityGroupRules"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "ArnNotLike": {
+          "aws:PrincipalArn": [
+            "arn:aws:iam::*:role/RoleCloudAdmin",
+            "arn:aws:iam::000111222333:role/RoleDevOpsLimitada",
+            "arn:aws:iam::*:user/FulanoCloudAdmin",
+            "arn:aws:iam::000111222333:user/FulanoDevopsLimitado",
+            "arn:aws:iam::*:role/RoleAutomacao",
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adiciona a Service Control Policy (SCP) RestrictSecurityGroupChanges, que restringe alterações em Security Groups para aumentar o controle de segurança em nível organizacional.

🎯 Objetivo
Reforçar as práticas de segurança impedindo alterações manuais ou não autorizadas em regras de Security Groups, garantindo que apenas entidades confiáveis possam realizar essas ações.